### PR TITLE
Changed the API from isDown to isPressed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,28 @@
-# keyb #
+# Keyb #
 
 A javascript utility for polling the state of the keyboard.
 
-## Installation ##
+### Usage ###
 
+For any given frame of your game, you can check to see if a key is pressed using `Keyb.isPressed(keyname)`:
+
+```js
+if(Keyb.isPressed("D") || Keyb.isPressed("<right>") {
+    player.position.x += 1
+}
 ```
-npm install keyb
+
+All methods accept a `keyname` as defined in [vkey](https://github.com/chrisdickinson/vkey), such as `1` or `A` or `<enter>`. Go to their [test page](http://didact.us/vkey) to experiment with how the keyboard is mapped.
+
+You can also check if a key was just pressed down using `Keyb.wasJustPressed(keyname, delta)`:
+
+```js
+if(Keyb.wasJustPressed("<space>")) {
+    player.throwPunch()
+}
 ```
 
-## Usage ##
-
-All methods accept `key` as strings from [vkey](https://github.com/chrisdickinson/vkey), such as `1` or `A` or `<enter>`. Go to their [test page](http://didact.us/vkey) to experiment with how the keyboard is mapped.
-
-### `keyb.isDown(key)` ###
-
-Returns true if the key is pushed.
-
-### `keyb.isUp(key)` ###
-
-Returns true if the key is not pushed.
-
-### `keyb.isJustDown(key, [delta])` ###
-
-Returns true if the key was pushed within the last few milliseconds, given as `delta`. If the `delta` is not given, the range is assumed to be 16.667ms, or 60fps.
-
-### `keyb.setDown(key)` ###
-
-Mocks a key being pushed.
-
-### `keyb.setUp(key)` ###
-
-Mocks a key being released.
+The older API is still supported, including `isDown` and `isJustDown`.
 
 ## License ##
 

--- a/index.js
+++ b/index.js
@@ -1,32 +1,36 @@
-var vkey = require("vkey")
+const vkey = require("vkey")
 
-var Keyb = {
-    isDown: function(key) {
+const Keyb = {
+    isPressed: function(key) {
         return this.data[key] != undefined
     },
-    isJustDown: function(key, delta) {
+    wasJustPressed: function(key, delta) {
         return window.performance.now() - this.data[key] < (delta || 1000 / 60)
     },
-    isUp: function(key) {
+    isNotPressed: function(key) {
         return this.data[key] == undefined
     },
-    setDown: function(key) {
+    setPressed: function(key) {
         this.data[key] = window.performance.now()
     },
-    setUp: function(key) {
+    setNotPressed: function(key) {
         delete this.data[key]
     },
     data: new Object()
 }
 
+Keyb.isDown = Keyb.isPressed
+Keyb.isJustDown = Keyb.wasJustPressed
+Keyb.isUp = Keyb.isNotPressed
+
 document.addEventListener("keydown", function(event) {
-    if(Keyb.isUp(vkey[event.keyCode])) {
-        Keyb.setDown(vkey[event.keyCode])
+    if(Keyb.isNotPressed(vkey[event.keyCode])) {
+        Keyb.setPressed(vkey[event.keyCode])
     }
 })
 
 document.addEventListener("keyup", function(event) {
-    Keyb.setUp(vkey[event.keyCode])
+    Keyb.setNotPressed(vkey[event.keyCode])
 })
 
 module.exports = Keyb


### PR DESCRIPTION
### Summary ###

`Keyb.isDown("<down>")` is confusing, and I'd rather use `Keyb.isPressed("<down>")` instead. The readme has been updated accordingly.